### PR TITLE
Infer type from default if provided but type omitted

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,13 +38,23 @@ Get them:
     'true'
     >>> getenv('BOOLEAN', type=bool)
     True
+    >>> getenv('BOOLEAN', default=False)
+    True
     >>> getenv('LIST', type=list)
+    ['a', 'b', 'c']
+    >>> getenv('LIST', default=[1, 2, 3])
     ['a', 'b', 'c']
     >>> getenv('LIST', type=tuple)
     ('a', 'b', 'c')
+    >>> getenv('LIST', default=(1, 2, 3))
+    ('a', 'b', 'c')
     >>> getenv('TRICKY_LIST', type=list, separator=':')
     ['d', 'e', 'f']
+    >>> getenv('TRICKY_LIST', default=[1, 2, 3], separator=':')
+    ['d', 'e', 'f']
     >>> getenv('DICT', type=dict)
+    {'foo': 'bar'}
+    >>> getenv('DICT', default={'key': 'value'})
     {'foo': 'bar'}
     >>> getenv('LOST', default='default value anyone?')
     'default value anyone?'

--- a/smart_getenv.py
+++ b/smart_getenv.py
@@ -1,8 +1,7 @@
 import os
 from ast import literal_eval
 
-
-__version__ = '1.1.0'
+__version__ = '1.2.0'
 
 
 def getenv(name, **kwargs):
@@ -10,9 +9,11 @@ def getenv(name, **kwargs):
     Retrieves environment variable by name and casts the value to desired type.
     If desired type is list or tuple - uses separator to split the value.
     """
-    default_value = kwargs.pop('default', None)
-    desired_type = kwargs.pop('type', str)
-    list_separator = kwargs.pop('separator', ',')
+    default_value = kwargs.get('default', None)
+    list_separator = kwargs.get('separator', ',')
+    desired_type = kwargs.get('type')
+    if not desired_type and default_value is not None:
+        desired_type = type(default_value)
 
     value = os.getenv(name, None)
 
@@ -28,7 +29,7 @@ def getenv(name, **kwargs):
         else:
             return bool(value)
 
-    if desired_type is list or desired_type is tuple:
+    if desired_type in (list, tuple):
         value = value.split(list_separator)
         return desired_type(value)
 

--- a/tests.py
+++ b/tests.py
@@ -40,6 +40,7 @@ class GetenvTests(unittest.TestCase):
         """
         os.environ[self.test_var_name] = 'abc'
         self.assertEqual(getenv(self.test_var_name, type=str), 'abc')
+        self.assertEqual(getenv(self.test_var_name, default='qwe'), 'abc')
 
     def test_getenv_type_int(self):
         """
@@ -58,6 +59,9 @@ class GetenvTests(unittest.TestCase):
         except ValueError:
             pass
 
+        os.environ[self.test_var_name] = '2'
+        self.assertEqual(getenv(self.test_var_name, default=1), 2)
+
     def test_getenv_type_float(self):
         """
         If environment variable exists and desired type is float:
@@ -74,6 +78,9 @@ class GetenvTests(unittest.TestCase):
                       ' non-castable to float value should fail with exception!')
         except ValueError:
             pass
+
+        os.environ[self.test_var_name] = '123.4'
+        self.assertEqual(getenv(self.test_var_name, default=245.6), 123.4)
 
     def test_getenv_type_bool(self):
         """
@@ -106,6 +113,9 @@ class GetenvTests(unittest.TestCase):
         os.environ[self.test_var_name] = ''
         self.assertEqual(getenv(self.test_var_name, type=bool), False)
 
+        os.environ[self.test_var_name] = 'absolutely not a boolean'
+        self.assertEqual(getenv(self.test_var_name, default=False), True)
+
     def test_getenv_type_list(self):
         """
         If environment variable exists and desired type is list:
@@ -125,6 +135,9 @@ class GetenvTests(unittest.TestCase):
         os.environ[self.test_var_name] = 'a:b:c'
         self.assertEqual(getenv(self.test_var_name, type=list, separator=':'), ['a', 'b', 'c'])
 
+        os.environ[self.test_var_name] = 'a,b,c'
+        self.assertEqual(getenv(self.test_var_name, default=[1, 2]), ['a', 'b', 'c'])
+
     def test_getenv_type_tuple(self):
         """
         If environment variable exists and desired type is tuple:
@@ -143,6 +156,9 @@ class GetenvTests(unittest.TestCase):
 
         os.environ[self.test_var_name] = 'a:b:c'
         self.assertEqual(getenv(self.test_var_name, type=tuple, separator=':'), ('a', 'b', 'c'))
+
+        os.environ[self.test_var_name] = 'a,b,c'
+        self.assertEqual(getenv(self.test_var_name, default=(1, 2)), ('a', 'b', 'c'))
 
     def test_getenv_type_dict(self):
         """
@@ -168,6 +184,9 @@ class GetenvTests(unittest.TestCase):
             pass
         except SyntaxError:
             pass
+
+        os.environ[self.test_var_name] = '{    "key":    "value"      }'
+        self.assertEqual(getenv(self.test_var_name, default={"key": "other value"}), {'key': 'value'})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change proposition adds inferring type from default value. It does that only when type keyword argument was not provided. Proper tests were added.

Oh, and dropped using .pop as it seems just unnecessary.

Feel free to pick only some part of this, or none, no pressure ;)

Cheers

PS: I'm not sure if I should update version..